### PR TITLE
fix: wrong yarn cmd in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ npm install ts-results
 ```
 or
 ```bash
-$ yarn install ts-results
+$ yarn add ts-results
 ```
 
 ## Example


### PR DESCRIPTION
yarn install is deprecated and throws error.

> ➜ yarn install ts-results

> yarn install v1.21.1

> error `install` has been replaced with `add` to add new dependencies. Run "yarn add ts-results" instead.
