### PR TITLE
Fix - Not working in node. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,14 @@
     "build": "npm run clean && tsc && copyfiles README.md LICENSE src/package.json dist --flat",
     "clean": "rm -rf dist"
   },
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
     "copyfiles": "^2.1.0",
     "rxjs": "^6.1.0",
-    "typescript": "^3.3.3"
+    "typescript": "^3.8.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export class Err<E> {
     }
 
     expect(msg: string): never {
-        let value = this.val.toString();
+        let value = String(this.val);
         if (value === '[object Object]') {
             try {
                 value = JSON.stringify(value);
@@ -28,7 +28,7 @@ export class Err<E> {
     }
 
     unwrap(): never {
-        let value = this.val.toString();
+        let value = String(this.val);
         if (value === '[object Object]') {
             try {
                 value = JSON.stringify(value);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,14 +5,14 @@
     "sourceMap": true,
     "declaration": true,
     "moduleResolution": "node",
-    "module": "es2015",
+    "module": "commonjs",
     "noEmitHelpers": false,
     "skipLibCheck": true,
     "lib": ["es2015"],
     "strict": true,
     "noImplicitReturns": true,
     "baseUrl": "./",
-    "target": "es6",
+    "target": "es5",
     "forceConsistentCasingInFileNames": true
   },
   "include": [


### PR DESCRIPTION
Lower the target to "es5" and the module to "commonjs" so it doesn't use es6 "exports".