### PR TITLE
Enhances

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+
+[{tsconfig.json,package.json}]
+indent_size = 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,12 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "conditional-type-checks": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/conditional-type-checks/-/conditional-type-checks-1.0.5.tgz",
+      "integrity": "sha512-DkfkvmjXVe4ye4llJ1JADtO3dNvqqcQM08cA9BhNt9Oe8pyRW8X1CZyBg9Qst05bDV9BJM01KLmnFh78NcJgNg==",
+      "dev": true
+    },
     "copyfiles": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.3.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,30 @@
 {
   "name": "ts-results",
-  "version": "1.1.1",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
+    },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+      "dev": true,
+      "requires": {
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -27,26 +43,35 @@
       }
     },
     "camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
     "cliui": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
       }
     },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
     "concat-map": {
@@ -56,17 +81,17 @@
       "dev": true
     },
     "copyfiles": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.1.0.tgz",
-      "integrity": "sha512-cAeDE0vL/koE9WSEGxqPpSyvU638Kgfu6wfrnj7kqp9FWa1CWsU54Coo6sdYZP4GstWa39tL/wIVJWfXcujgNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.3.0.tgz",
+      "integrity": "sha512-73v7KFuDFJ/ofkQjZBMjMBFWGgkS76DzXvBMUh7djsMOE5EELWtAO/hRB6Wr5Vj5Zg+YozvoHemv0vnXpqxmOQ==",
       "dev": true,
       "requires": {
         "glob": "^7.0.5",
         "minimatch": "^3.0.3",
-        "mkdirp": "^0.5.1",
+        "mkdirp": "^1.0.4",
         "noms": "0.0.0",
         "through2": "^2.0.1",
-        "yargs": "^11.0.0"
+        "yargs": "^15.3.1"
       }
     },
     "core-util-is": {
@@ -75,45 +100,26 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
-    "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      }
-    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
-    "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      }
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
       }
     },
     "fs.realpath": {
@@ -123,21 +129,15 @@
       "dev": true
     },
     "get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-      "dev": true
-    },
-    "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -159,27 +159,15 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
     "isarray": {
@@ -188,55 +176,14 @@
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
-      "requires": {
-        "invert-kv": "^1.0.0"
-      }
-    },
     "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "^4.1.0"
       }
-    },
-    "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dev": true,
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "mem": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "^1.0.0"
-      }
-    },
-    "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -247,20 +194,11 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
-    },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
-      }
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
     },
     "noms": {
       "version": "0.0.0",
@@ -272,21 +210,6 @@
         "readable-stream": "~1.0.31"
       }
     },
-    "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
-      "requires": {
-        "path-key": "^2.0.0"
-      }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -296,51 +219,34 @@
         "wrappy": "1"
       }
     },
-    "os-locale": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-      "dev": true,
-      "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
-      }
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
-    },
     "p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "^2.0.0"
       }
     },
     "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "^2.2.0"
       }
     },
     "p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
     "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true
     },
     "path-is-absolute": {
@@ -349,22 +255,10 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
-    },
     "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
     "readable-stream": {
@@ -386,15 +280,15 @@
       "dev": true
     },
     "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
     "rxjs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
-      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
+      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -412,35 +306,15 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
-      "requires": {
-        "shebang-regex": "^1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
-    },
-    "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
-    },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
       }
     },
     "string_decoder": {
@@ -450,19 +324,13 @@
       "dev": true
     },
     "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "^5.0.0"
       }
-    },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
     },
     "through2": {
       "version": "2.0.5",
@@ -481,9 +349,9 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -507,15 +375,15 @@
       }
     },
     "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
       "dev": true
     },
     "typescript": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3.tgz",
-      "integrity": "sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
+      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
       "dev": true
     },
     "util-deprecate": {
@@ -524,15 +392,6 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
-    "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "requires": {
-        "isexe": "^2.0.0"
-      }
-    },
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
@@ -540,50 +399,14 @@
       "dev": true
     },
     "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       }
     },
     "wrappy": {
@@ -593,50 +416,44 @@
       "dev": true
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
     "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-      "dev": true
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
     "yargs": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-      "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+      "version": "15.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+      "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
       "dev": true,
       "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^1.1.1",
-        "find-up": "^2.1.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^2.0.0",
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
+        "require-main-filename": "^2.0.0",
         "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
+        "string-width": "^4.2.0",
         "which-module": "^2.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^9.0.2"
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.1"
       }
     },
     "yargs-parser": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-      "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dev": true,
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "copyfiles": "^2.1.0",
-    "rxjs": "^6.1.0",
-    "typescript": "^3.3.3"
+    "copyfiles": "^2.3.0",
+    "rxjs": "^6.5.5",
+    "typescript": "^3.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "description": "",
   "scripts": {
     "build": "npm run clean && tsc && copyfiles README.md LICENSE src/package.json dist --flat",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test": "tsc -p ./test/tsconfig.json"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "conditional-type-checks": "^1.0.5",
     "copyfiles": "^2.3.0",
     "rxjs": "^6.5.5",
     "typescript": "^3.9.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,12 @@
+function toString(val: unknown) {
+    let value = ''.toString.call(val);
+    if (value === '[object Object]') {
+        try {
+            value = JSON.stringify(value);
+        } catch {}
+    }
+    return value
+}
 export class Err<E> {
     static readonly EMPTY = new Err<void>(undefined);
 
@@ -16,30 +25,14 @@ export class Err<E> {
     }
 
     expect(msg: string): never {
-        let value = this.val.toString();
-        if (value === '[object Object]') {
-            try {
-                value = JSON.stringify(value);
-            } catch (e) {
-
-            }
-        }
-        throw new Error(`${msg} - Error: ${value}`);
+        throw new Error(`${msg} - Error: ${toString(this.val)}`);
     }
 
     unwrap(): never {
-        let value = this.val.toString();
-        if (value === '[object Object]') {
-            try {
-                value = JSON.stringify(value);
-            } catch (e) {
-
-            }
-        }
-        throw new Error(`Tried to unwrap Error: ${value}`);
+        throw new Error(`Tried to unwrap Error: ${toString(this.val)}`);
     }
 
-    map<T2>(mapper: (val: never) => T2): Err<E> {
+    map<T2>(_mapper: (val: never) => T2): Err<E> {
         return this;
     }
 
@@ -54,18 +47,17 @@ export class Ok<T> {
     readonly ok = true;
     readonly err = false;
 
-    constructor(public readonly val: T) {
-    }
+    constructor(public readonly val: T) {}
 
     /**
      * If the result has a value returns that value.  Otherwise returns the passed in value.
-     * @param val the value to replace the error with
+     * @param _val the value to replace the error with
      */
-    else<T2>(val: T2):  T {
+    else<T2>(_val: T2):  T {
         return this.val;
     }
 
-    expect(msg: string): T {
+    expect(_msg: string): T {
         return this.val;
     }
 
@@ -77,7 +69,7 @@ export class Ok<T> {
         return new Ok(mapper(this.val));
     }
 
-    mapErr<E2>(mapper: (err: never) => E2): Ok<T> {
+    mapErr<E2>(_mapper: (err: never) => E2): Ok<T> {
         return this;
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,22 +137,42 @@ export type Result<T, E> = (Ok<T> | Err<E>) & Base<T, E>;
 
 export type ResultOkType<T extends Result<any, any>> = T extends Result<infer U, any> ? U : never;
 export type ResultErrType<T extends Result<any, any>> = T extends Result<any, infer U> ? U : never;
+// Suggest to rename to all
+/**
+ * Parse a set of `Result`s, short-circuits when an input value is `Err`.
+ */
 export function Results(): Result<[], never>;
 export function Results<T1, E1>(result1: Result<T1, E1>): Result<[T1], E1>;
 export function Results<T1, E1, T2, E2>(result1: Result<T1, E1>, result2: Result<T2, E2>): Result<[T1, T2], E1 | E2>;
 export function Results<T1, E1, T2, E2, T3, E3>(result1: Result<T1, E1>, result2: Result<T2, E2>, result3: Result<T3, E3>): Result<[T1, T2, T3], E1 | E2 | E3>;
 export function Results<T1, E1, T2, E2, T3, E3, T4, E4>(result1: Result<T1, E1>, result2: Result<T2, E2>, result3: Result<T3, E3>, result4: Result<T4, E4>): Result<[T1, T2, T3, T4], E1 | E2 | E3 | E4>;
-export function Results(...results: Result<any, any>[]): Result<any[], any>;
+export function Results<T, E>(...results: Result<T, E>[]): Result<T[], E>;
 export function Results(...results: Result<any, any>[]): Result<any[], any> {
     const okResult = [];
     for (let result of results) {
         if (result.ok) {
             okResult.push(result.val);
         } else {
-            return new Err(result.val);
+            return result.val;
         }
     }
     return new Ok(okResult);
+}
+/**
+ * Parse a set of `Result`s, short-circuits when an input value is `Ok`.
+ */
+export function any(): Result<void, never>;
+export function any<T1, E1>(result1: Result<T1, E1>): Result<T1, E1>;
+export function any<T1, E1, T2, E2>(result1: Result<T1, E1>, result2: Result<T2, E2>): Result<T1 | T2, E1 | E2>;
+export function any<T1, E1, T2, E2, T3, E3>(result1: Result<T1, E1>, result2: Result<T2, E2>, result3: Result<T3, E3>): Result<T1 | T2 | T3, E1 | E2 | E3>;
+export function any<T1, E1, T2, E2, T3, E3, T4, E4>(result1: Result<T1, E1>, result2: Result<T2, E2>, result3: Result<T3, E3>, result4: Result<T4, E4>): Result<T1 | T2 | T3 | T4, E1 | E2 | E3 | E4>;
+export function any<T, E>(...results: Result<T, E>[]): Result<T, E>;
+export function any(...results: Result<any, any>[]): Result<any, any> {
+    // short-circuits
+    for (const result of results) if (result.ok) return result;
+    if (results.length === 0) return Ok.EMPTY;
+    // it must be a Err
+    return results[results.length - 1];
 }
 function toString(val: unknown) {
     let value = "".toString.call(val);

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,10 @@ export class Err<E> {
         return this;
     }
 
+    flatMap<T2, E2>(mapper: (val: never) => Result<T2, E2>): Err<E> {
+        return this;
+    }
+
     mapErr<E2>(mapper: (err: E) => E2): Err<E2> {
         return new Err(mapper(this.val));
     }
@@ -83,6 +87,10 @@ export class Ok<T> {
         return new Ok(mapper(this.val));
     }
 
+    flatMap<T2, E2>(mapper: (val: T) => Result<T2, E2>): Result<T2, E2> {
+        return mapper(this.val);
+    }
+
     mapErr<E2>(_mapper: (err: never) => E2): Ok<T> {
         return this;
     }
@@ -90,7 +98,7 @@ export class Ok<T> {
 
 export type Result<T, E> = (Ok<T> | Err<E>) & {
     map<T2>(mapper: (val: T) => T2): Result<T2, E>;
-
+    flatMap<T2, E2>(mapper: (val: T) => Result<T2, E2>): Result<T2, E | E2>;
     mapErr<E2>(mapper: (val: E) => E2): Result<T, E2>;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,9 @@ export class Err<E> {
     readonly ok = false;
     readonly err = true;
 
+    [Symbol.iterator](): Iterator<never, never, any> {
+        return { next(): IteratorResult<never, never> { return { done: true, value: undefined! } } }
+    }
     constructor(public readonly val: E) {}
 
     /**
@@ -65,7 +68,12 @@ export class Ok<T> {
     readonly ok = true;
     readonly err = false;
 
-    constructor(public readonly val: T) {}
+    [Symbol.iterator](): T extends Iterable<infer U> ? Iterator<U> : never {
+        // @ts-ignore
+        return this.val[Symbol.iterator]()
+    }
+    constructor(public readonly val: T) {
+    }
 
     /**
      * If the result has a value returns that value.  Otherwise returns the passed in value.

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,14 +7,24 @@ function toString(val: unknown) {
     }
     return value
 }
+function callable(constructor: any) {
+    return new Proxy(constructor, {
+        apply(target: any, thisArg: any, argArray?: any) {
+            return new target(...argArray)
+        }
+    })
+}
+// @ts-expect-error Duplicate identifier 'Err'.ts(2300)
+export declare function Err<E>(val: E): Err<E>;
+@callable
+// @ts-expect-error Duplicate identifier 'Err'.ts(2300)
 export class Err<E> {
     static readonly EMPTY = new Err<void>(undefined);
 
     readonly ok = false;
     readonly err = true;
 
-    constructor(public readonly val: E) {
-    }
+    constructor(public readonly val: E) {}
 
     /**
      * If the result has a value returns that value.  Otherwise returns the passed in value.
@@ -41,6 +51,10 @@ export class Err<E> {
     }
 }
 
+// @ts-expect-error Duplicate identifier 'Ok'.ts(2300)
+export declare function Ok<T>(val: T): Ok<T>;
+@callable
+// @ts-expect-error Duplicate identifier 'Ok'.ts(2300)
 export class Ok<T> {
     static readonly EMPTY = new Ok<void>(undefined);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export class Ok<T> {
      * If the result has a value returns that value.  Otherwise returns the passed in value.
      * @param _val the value to replace the error with
      */
-    else<T2>(_val: T2):  T {
+    else(_val: unknown): T {
         return this.val;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,8 @@ export type Result<T, E> = (Ok<T> | Err<E>) & {
 export type ResultOkType<T extends Result<any, any>> = T extends Result<infer U, any> ? U : never;
 export type ResultErrType<T extends Result<any, any>> = T extends Result<any, infer U> ? U : never;
 
+export function Results(): Result<[], never>
+export function Results<T1, E1>(result1: Result<T1, E1>): Result<[T1], E1>
 export function Results<T1, E1, T2, E2>(result1: Result<T1, E1>, result2: Result<T2, E2>): Result<[T1, T2], E1 | E2>
 export function Results<T1, E1, T2, E2, T3, E3>(result1: Result<T1, E1>, result2: Result<T2, E2>, result3: Result<T3, E3>): Result<[T1, T2, T3], E1 | E2 | E3>
 export function Results<T1, E1, T2, E2, T3, E3, T4, E4>(result1: Result<T1, E1>, result2: Result<T2, E2>, result3: Result<T3, E3>, result4: Result<T4, E4>): Result<[T1, T2, T3, T4], E1 | E2 | E3 | E4>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,25 @@
 function toString(val: unknown) {
-    let value = ''.toString.call(val);
-    if (value === '[object Object]') {
+    let value = "".toString.call(val);
+    if (value === "[object Object]") {
         try {
             value = JSON.stringify(value);
         } catch {}
     }
-    return value
+    return value;
 }
 function callable(constructor: any) {
     return new Proxy(constructor, {
         apply(target: any, thisArg: any, argArray?: any) {
-            return new target(...argArray)
-        }
-    })
+            return new target(...argArray);
+        },
+    });
+}
+function wrap<T>(x: () => T) {
+    try {
+        return new Ok(x());
+    } catch (e) {
+        return new Err<unknown>(e);
+    }
 }
 // @ts-expect-error Duplicate identifier 'Err'.ts(2300)
 export declare function Err<E>(val: E): Err<E>;
@@ -20,12 +27,17 @@ export declare function Err<E>(val: E): Err<E>;
 // @ts-expect-error Duplicate identifier 'Err'.ts(2300)
 export class Err<E> {
     static readonly EMPTY = new Err<void>(undefined);
+    static wrap = wrap;
 
     readonly ok = false;
     readonly err = true;
 
     [Symbol.iterator](): Iterator<never, never, any> {
-        return { next(): IteratorResult<never, never> { return { done: true, value: undefined! } } }
+        return {
+            next(): IteratorResult<never, never> {
+                return { done: true, value: undefined! };
+            },
+        };
     }
     constructor(public readonly val: E) {}
 
@@ -64,16 +76,16 @@ export declare function Ok<T>(val: T): Ok<T>;
 // @ts-expect-error Duplicate identifier 'Ok'.ts(2300)
 export class Ok<T> {
     static readonly EMPTY = new Ok<void>(undefined);
+    static wrap = wrap;
 
     readonly ok = true;
     readonly err = false;
 
     [Symbol.iterator](): T extends Iterable<infer U> ? Iterator<U> : never {
         // @ts-ignore
-        return this.val[Symbol.iterator]()
+        return this.val[Symbol.iterator]();
     }
-    constructor(public readonly val: T) {
-    }
+    constructor(public readonly val: T) {}
 
     /**
      * If the result has a value returns that value.  Otherwise returns the passed in value.
@@ -112,13 +124,12 @@ export type Result<T, E> = (Ok<T> | Err<E>) & {
 
 export type ResultOkType<T extends Result<any, any>> = T extends Result<infer U, any> ? U : never;
 export type ResultErrType<T extends Result<any, any>> = T extends Result<any, infer U> ? U : never;
-
-export function Results(): Result<[], never>
-export function Results<T1, E1>(result1: Result<T1, E1>): Result<[T1], E1>
-export function Results<T1, E1, T2, E2>(result1: Result<T1, E1>, result2: Result<T2, E2>): Result<[T1, T2], E1 | E2>
-export function Results<T1, E1, T2, E2, T3, E3>(result1: Result<T1, E1>, result2: Result<T2, E2>, result3: Result<T3, E3>): Result<[T1, T2, T3], E1 | E2 | E3>
-export function Results<T1, E1, T2, E2, T3, E3, T4, E4>(result1: Result<T1, E1>, result2: Result<T2, E2>, result3: Result<T3, E3>, result4: Result<T4, E4>): Result<[T1, T2, T3, T4], E1 | E2 | E3 | E4>
-export function Results(...results: Result<any, any>[]): Result<any[], any>
+export function Results(): Result<[], never>;
+export function Results<T1, E1>(result1: Result<T1, E1>): Result<[T1], E1>;
+export function Results<T1, E1, T2, E2>(result1: Result<T1, E1>, result2: Result<T2, E2>): Result<[T1, T2], E1 | E2>;
+export function Results<T1, E1, T2, E2, T3, E3>(result1: Result<T1, E1>, result2: Result<T2, E2>, result3: Result<T3, E3>): Result<[T1, T2, T3], E1 | E2 | E3>;
+export function Results<T1, E1, T2, E2, T3, E3, T4, E4>(result1: Result<T1, E1>, result2: Result<T2, E2>, result3: Result<T3, E3>, result4: Result<T4, E4>): Result<[T1, T2, T3, T4], E1 | E2 | E3 | E4>;
+export function Results(...results: Result<any, any>[]): Result<any[], any>;
 export function Results(...results: Result<any, any>[]): Result<any[], any> {
     const okResult = [];
     for (let result of results) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,6 @@ export declare function Err<E>(val: E): Err<E>;
 export class Err<E> implements Base<never, E> {
     /** An empty Err */
     static readonly EMPTY = new Err<void>(undefined);
-    static wrap = wrap;
 
     readonly ok = false;
     readonly err = true;
@@ -105,7 +104,6 @@ export declare function Ok<T>(val: T): Ok<T>;
 // @ts-expect-error Duplicate identifier 'Ok'.ts(2300)
 export class Ok<T> implements Base<T, never> {
     static readonly EMPTY = new Ok<void>(undefined);
-    static wrap = wrap;
 
     readonly ok = true;
     readonly err = false;
@@ -176,7 +174,7 @@ function callable(constructor: any) {
  * Wrap a operation that may throw an Error (`try-catch` style) into checked exception style
  * @param op The operation function
  */
-function wrap<T>(op: () => T) {
+export function wrap<T>(op: () => T) {
     try {
         return new Ok(op());
     } catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@
  * pub fn expect_err(self, msg: &str) -> E
  * pub fn unwrap_err(self) -> E
  * pub fn unwrap_or_default(self) -> T
- * pub fn into_ok(self) -> T
  */
 
 // This interface is used to inherit document
@@ -33,6 +32,8 @@ interface Base<T, E> {
     // Suggestion: Rename to unwrapOr
     /**
      * Returns the contained `Ok` value or a provided default.
+     * 
+     *  (This is the `unwrap_or` in rust)
      */
     else<T2>(val: T2): T | T2;
     /**
@@ -54,6 +55,15 @@ interface Base<T, E> {
      * This function can be used to pass through a successful result while handling an error.
      */
     mapErr<F>(mapper: (val: E) => F): Result<T, F>;
+    /**
+     * Returns the contained `Ok` value, but never throws.
+     * Unlike `unwrap()`, this method is known to never throw on the result types.
+     * Therefore, it can be used instead of `unwrap()` as a maintainability safeguard
+     * that will fail to compile if the error type of the Result is later changed to an error that can actually occur.
+     * 
+     * (this is the `into_ok()` in rust)
+     */
+    safeUnwrap: unknown;
 }
 /**
  * Contains the error value
@@ -96,6 +106,7 @@ export class Err<E> implements Base<never, E> {
     mapErr<E2>(mapper: (err: E) => E2): Err<E2> {
         return new Err(mapper(this.val));
     }
+    declare safeUnwrap: unknown
 }
 
 // @ts-expect-error Duplicate identifier 'Ok'.ts(2300)
@@ -130,6 +141,9 @@ export class Ok<T> implements Base<T, never> {
     }
     mapErr<E2>(_mapper: (err: never) => E2): Ok<T> {
         return this;
+    }
+    safeUnwrap() {
+        return this.val;
     }
 }
 

--- a/src/rxjs-operators.ts
+++ b/src/rxjs-operators.ts
@@ -11,6 +11,7 @@ export function resultMap<R extends Result<any, any>, T>(mapper: (val: ResultOkT
 }
 
 export function resultMapErr<R extends Result<any, any>, E>(mapper: (val: ResultErrType<R>) => E): OperatorFunction<R, Result<ResultOkType<R>, E>> {
+    // @ts-ignore Help wanted
     return (source: Observable<R>) => {
         return source.pipe(
           map(result => result.mapErr(mapper))
@@ -27,6 +28,7 @@ export function resultMapTo<R extends Result<any, any>, T>(value: T): OperatorFu
 }
 
 export function resultMapErrTo<R extends Result<any, any>, T>(value: T): OperatorFunction<R, Result<ResultOkType<R>, T>> {
+    // @ts-ignore Help wanted
     return (source: Observable<R>) => {
         return source.pipe(
           map(result => result.mapErr(() => value))

--- a/test/index.ts
+++ b/test/index.ts
@@ -6,11 +6,19 @@ import {
   ResultOkType,
   ResultErrType,
   Results,
-} from "../src/index";
+} from "../dist/index";
 
 declare function work(): Result<string, number>;
 declare function ok(): Ok<string>;
 declare function err(): Err<number>;
+//#region Callable
+{
+  const x = Err(0);
+  eq<Err<number>, typeof x>(true);
+  const y = Ok(0);
+  eq<Ok<number>, typeof y>(true);
+}
+//#endregion
 //#region ok, err, val
 {
   const r = new Err(0);

--- a/test/index.ts
+++ b/test/index.ts
@@ -9,6 +9,7 @@ import {
 } from "../dist/index";
 
 declare function work(): Result<string, number>;
+declare function work2(x: string): Result<symbol, string>;
 declare function ok(): Ok<string>;
 declare function err(): Err<number>;
 //#region Callable
@@ -119,6 +120,16 @@ eq<typeof Ok.EMPTY, Ok<void>>(true);
   eq<typeof r3, Result<symbol, number>>(true);
 }
 //#endregion
+//#region flatMap
+{
+  const r1 = ok().flatMap(work);
+  eq<typeof r1, Result<string, number>>(true);
+  const r2 = err().flatMap(work);
+  eq<typeof r2, Err<number>>(true);
+  const r3 = work().flatMap(work2);
+  eq<typeof r3, Result<symbol, string | number>>(true);
+}
+//#endregion
 //#region mapErr(mapper)
 {
   const r1 = ok().mapErr(Symbol);
@@ -161,6 +172,6 @@ eq<typeof Ok.EMPTY, Ok<void>>(true);
   eq<typeof r3, Result<[string, never, string], number>>(true);
 }
 //#endregion
-function expect_string(x: string) {}
+function expect_string(x: string) { }
 function expect_never(x: never) {}
 function eq<A, B>(x: IsExact<A, B>) {}

--- a/test/index.ts
+++ b/test/index.ts
@@ -158,13 +158,11 @@ eq<typeof Ok.EMPTY, Ok<void>>(true);
   eq<number, c>(true);
 }
 //#endregion
-//#region !!! NOT PASSING: Results(...args)
+//#region Results(...args)
 {
   const r0 = Results();
-  // @ts-expect-error, actually Result<any[], any>
-  eq<typeof r0, Result<[], void>>(true);
+  eq<typeof r0, Result<[], never>>(true);
   const r1 = Results(work());
-  // @ts-expect-error, actually Result<any[], any>
   eq<typeof r1, Result<[string], number>>(true);
   const r2 = Results(work(), work());
   eq<typeof r2, Result<[string, string], number>>(true);
@@ -172,6 +170,6 @@ eq<typeof Ok.EMPTY, Ok<void>>(true);
   eq<typeof r3, Result<[string, never, string], number>>(true);
 }
 //#endregion
-function expect_string(x: string) { }
+function expect_string(x: string) {}
 function expect_never(x: never) {}
 function eq<A, B>(x: IsExact<A, B>) {}

--- a/test/index.ts
+++ b/test/index.ts
@@ -6,6 +6,7 @@ import {
     ResultOkType,
     ResultErrType,
     Results,
+    wrap,
 } from "../dist/index";
 
 declare function work(): Result<string, number>;
@@ -199,7 +200,7 @@ eq<typeof Ok.EMPTY, Ok<void>>(true);
 //#endregion
 //#region static wrap
 {
-    const a = Ok.wrap(() => 1);
+    const a = wrap(() => 1);
     assert<IsExact<typeof a, Result<number, unknown>>>(true);
 }
 //#endregion

--- a/test/index.ts
+++ b/test/index.ts
@@ -222,6 +222,19 @@ eq<typeof Ok.EMPTY, Ok<void>>(true);
     assert<IsExact<typeof a, Result<number, unknown>>>(true);
 }
 //#endregion
+//#region safeUnwrap
+{
+    expect_string(ok().safeUnwrap(), true);
+    // @ts-expect-error
+    err().safeUnwrap();
+    // @ts-expect-error
+    work().safeUnwrap();
+    const k = work();
+    if (k.ok) k.safeUnwrap();
+    // @ts-expect-error
+    else k.safeUnwrap();
+}
+//#endregion
 function expect_string<T>(x: T, y: IsExact<T, string>) {}
 function expect_never<T>(x: T, y: IsNever<T>) {}
 function eq<A, B>(x: IsExact<A, B>) {}

--- a/test/index.ts
+++ b/test/index.ts
@@ -7,6 +7,7 @@ import {
     ResultErrType,
     Results,
     wrap,
+    any,
 } from "../dist/index";
 
 declare function work(): Result<string, number>;
@@ -169,6 +170,23 @@ eq<typeof Ok.EMPTY, Ok<void>>(true);
     eq<typeof r2, Result<[string, string], number>>(true);
     const r3 = Results(ok(), err(), work());
     eq<typeof r3, Result<[string, never, string], number>>(true);
+    const r4 = Results(...([] as Result<string, number>[]));
+    eq<typeof r4, Result<string[], number>>(true);
+}
+//#endregion
+//#region any(...args)
+{
+    type T = Result<string, number>;
+    const r0 = any();
+    eq<typeof r0, Result<void, never>>(true);
+    const r1 = any(work());
+    eq<typeof r1, T>(true);
+    const r2 = any(work(), work());
+    eq<typeof r2, T>(true);
+    const r3 = any(ok(), err(), work());
+    eq<typeof r3, T>(true);
+    const r4 = any(...([] as Result<string, number>[]));
+    eq<typeof r4, T>(true);
 }
 //#endregion
 //#region Iterable<T>

--- a/test/index.ts
+++ b/test/index.ts
@@ -69,7 +69,7 @@ eq<typeof Ok.EMPTY, Ok<void>>(true);
   }
 }
 //#endregion
-//#region !!! NOT PASSING: else(val)
+//#region else(val)
 {
   const r1 = ok().else(false);
   expect_string(r1);
@@ -77,10 +77,7 @@ eq<typeof Ok.EMPTY, Ok<void>>(true);
   const r2 = err().else(false);
   eq<false, typeof r2>(true);
 
-  // FIXME: GH#4 TS2349: This expression (Result<?, ?>.else) is not callable
-  // @ts-expect-error
   const r3 = work().else(false);
-  // @ts-expect-error
   eq<typeof r3, string | false>(true);
 }
 //#endregion

--- a/test/index.ts
+++ b/test/index.ts
@@ -120,13 +120,13 @@ eq<typeof Ok.EMPTY, Ok<void>>(true);
     eq<typeof r3, Result<symbol, number>>(true);
 }
 //#endregion
-//#region flatMap
+//#region andThen
 {
-    const r1 = ok().flatMap(work);
+    const r1 = ok().andThen(work);
     eq<typeof r1, Result<string, number>>(true);
-    const r2 = err().flatMap(work);
+    const r2 = err().andThen(work);
     eq<typeof r2, Err<number>>(true);
-    const r3 = work().flatMap(work2);
+    const r3 = work().andThen(work2);
     eq<typeof r3, Result<symbol, string | number>>(true);
 }
 //#endregion

--- a/test/index.ts
+++ b/test/index.ts
@@ -16,13 +16,13 @@ declare function err(): Err<number>;
   const r = new Err(0);
   assert<typeof r.err>(true);
   assert<typeof r.ok>(false);
-  assert<IsExact<typeof r.val, number>>(true);
+  eq<typeof r.val, number>(true);
 }
 {
   const r = new Ok(0);
   assert<typeof r.err>(false);
   assert<typeof r.ok>(true);
-  assert<IsExact<typeof r.val, number>>(true);
+  eq<typeof r.val, number>(true);
 }
 //#endregion
 //#region Ok<T> & Err<E> should be Result<T, E>
@@ -30,26 +30,26 @@ declare function err(): Err<number>;
   const r1 = new Err(0);
   const r2 = new Ok("");
   const r = Math.random() ? r1 : r2;
-  assert<IsExact<typeof r, Result<string, number>>>(true);
+  eq<typeof r, Result<string, number>>(true);
 }
 //#endregion
 //#region static EMPTY
-assert<IsExact<typeof Err.EMPTY, Err<void>>>(true);
-assert<IsExact<typeof Ok.EMPTY, Ok<void>>>(true);
+eq<typeof Err.EMPTY, Err<void>>(true);
+eq<typeof Ok.EMPTY, Ok<void>>(true);
 //#endregion
 //#region Type narrowing test (tagged union)
 {
   const r = work();
   if (r.ok) {
-    assert<IsExact<typeof r, Ok<string>>>(true);
+    eq<typeof r, Ok<string>>(true);
   } else {
-    assert<IsExact<typeof r, Err<number>>>(true);
+    eq<typeof r, Err<number>>(true);
   }
   // ---------------------------------------------
   if (r.err) {
-    assert<IsExact<typeof r, Err<number>>>(true);
+    eq<typeof r, Err<number>>(true);
   } else {
-    assert<IsExact<typeof r, Ok<string>>>(true);
+    eq<typeof r, Ok<string>>(true);
   }
 }
 //#endregion
@@ -57,15 +57,15 @@ assert<IsExact<typeof Ok.EMPTY, Ok<void>>>(true);
 {
   const r = work();
   if (r instanceof Ok) {
-    assert<IsExact<typeof r, Ok<string>>>(true);
+    eq<typeof r, Ok<string>>(true);
   } else {
-    assert<IsExact<typeof r, Err<number>>>(true);
+    eq<typeof r, Err<number>>(true);
   }
   // ---------------------------------------------
   if (r instanceof Err) {
-    assert<IsExact<typeof r, Err<number>>>(true);
+    eq<typeof r, Err<number>>(true);
   } else {
-    assert<IsExact<typeof r, Ok<string>>>(true);
+    eq<typeof r, Ok<string>>(true);
   }
 }
 //#endregion
@@ -75,13 +75,13 @@ assert<IsExact<typeof Ok.EMPTY, Ok<void>>>(true);
   expect_string(r1);
 
   const r2 = err().else(false);
-  assert<IsExact<false, typeof r2>>(true);
+  eq<false, typeof r2>(true);
 
   // FIXME: GH#4 TS2349: This expression (Result<?, ?>.else) is not callable
   // @ts-expect-error
   const r3 = work().else(false);
   // @ts-expect-error
-  assert<IsExact<typeof r3, string | false>>(true);
+  eq<typeof r3, string | false>(true);
 }
 //#endregion
 //#region expect(msg)
@@ -107,54 +107,55 @@ assert<IsExact<typeof Ok.EMPTY, Ok<void>>>(true);
 //#region map(mapper)
 {
   const r1 = ok().map(Symbol);
-  assert<IsExact<typeof r1, Ok<symbol>>>(true);
+  eq<typeof r1, Ok<symbol>>(true);
   const r2 = err().map((x) => Symbol());
-  assert<IsExact<typeof r2, Err<number>>>(true);
+  eq<typeof r2, Err<number>>(true);
   const r3 = work().map(Symbol);
-  assert<IsExact<typeof r3, Result<symbol, number>>>(true);
+  eq<typeof r3, Result<symbol, number>>(true);
 }
 //#endregion
 //#region mapErr(mapper)
 {
   const r1 = ok().mapErr(Symbol);
-  assert<IsExact<typeof r1, Ok<string>>>(true);
+  eq<typeof r1, Ok<string>>(true);
   const r2 = err().mapErr((x) => Symbol());
-  assert<IsExact<typeof r2, Err<symbol>>>(true);
+  eq<typeof r2, Err<symbol>>(true);
   const r3 = work().mapErr(Symbol);
-  assert<IsExact<typeof r3, Result<string, symbol>>>(true);
+  eq<typeof r3, Result<string, symbol>>(true);
 }
 //#endregion
 //#region ResultOkType & ResultErrType
 {
   type a = ResultOkType<Ok<string>>;
-  assert<IsExact<string, a>>(true);
+  eq<string, a>(true);
   type b = ResultOkType<Err<string>>;
-  assert<IsExact<never, b>>(true);
+  eq<never, b>(true);
   type c = ResultOkType<Result<string, number>>;
-  assert<IsExact<string, c>>(true);
+  eq<string, c>(true);
 }
 {
   type a = ResultErrType<Ok<string>>;
-  assert<IsExact<never, a>>(true);
+  eq<never, a>(true);
   type b = ResultErrType<Err<string>>;
-  assert<IsExact<string, b>>(true);
+  eq<string, b>(true);
   type c = ResultErrType<Result<string, number>>;
-  assert<IsExact<number, c>>(true);
+  eq<number, c>(true);
 }
 //#endregion
 //#region !!! NOT PASSING: Results(...args)
 {
   const r0 = Results();
   // @ts-expect-error, actually Result<any[], any>
-  assert<IsExact<typeof r0, Result<[], void>>>(true);
+  eq<typeof r0, Result<[], void>>(true);
   const r1 = Results(work());
   // @ts-expect-error, actually Result<any[], any>
-  assert<IsExact<typeof r1, Result<[string], number>>>(true);
+  eq<typeof r1, Result<[string], number>>(true);
   const r2 = Results(work(), work());
-  assert<IsExact<typeof r2, Result<[string, string], number>>>(true);
+  eq<typeof r2, Result<[string, string], number>>(true);
   const r3 = Results(ok(), err(), work());
-  assert<IsExact<typeof r3, Result<[string, never, string], number>>>(true);
+  eq<typeof r3, Result<[string, never, string], number>>(true);
 }
 //#endregion
 function expect_string(x: string) {}
 function expect_never(x: never) {}
+function eq<A, B>(x: IsExact<A, B>) {}

--- a/test/index.ts
+++ b/test/index.ts
@@ -172,13 +172,20 @@ eq<typeof Ok.EMPTY, Ok<void>>(true);
     eq<typeof r3, Result<[string, never, string], number>>(true);
     const r4 = Results(...([] as Result<string, number>[]));
     eq<typeof r4, Result<string[], number>>(true);
+    const r5 = Results(
+        Ok(2 as const),
+        Err(1 as const),
+        Ok(3 as const),
+        Err(0 as const)
+    );
+    eq<typeof r5, Result<[2, never, 3, never], 1 | 0>>(true);
 }
 //#endregion
 //#region any(...args)
 {
     type T = Result<string, number>;
     const r0 = any();
-    eq<typeof r0, Result<void, never>>(true);
+    eq<typeof r0, Result<never, never>>(true);
     const r1 = any(work());
     eq<typeof r1, T>(true);
     const r2 = any(work(), work());
@@ -187,6 +194,13 @@ eq<typeof Ok.EMPTY, Ok<void>>(true);
     eq<typeof r3, T>(true);
     const r4 = any(...([] as Result<string, number>[]));
     eq<typeof r4, T>(true);
+    const r5 = any(
+        Ok(2 as const),
+        Err(1 as const),
+        Ok(3 as const),
+        Err(0 as const)
+    );
+    eq<typeof r5, Result<2 | 3, 1 | 0>>(true);
 }
 //#endregion
 //#region Iterable<T>

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,160 @@
+import { assert, IsExact } from "conditional-type-checks";
+import {
+  Err,
+  Ok,
+  Result,
+  ResultOkType,
+  ResultErrType,
+  Results,
+} from "../src/index";
+
+declare function work(): Result<string, number>;
+declare function ok(): Ok<string>;
+declare function err(): Err<number>;
+//#region ok, err, val
+{
+  const r = new Err(0);
+  assert<typeof r.err>(true);
+  assert<typeof r.ok>(false);
+  assert<IsExact<typeof r.val, number>>(true);
+}
+{
+  const r = new Ok(0);
+  assert<typeof r.err>(false);
+  assert<typeof r.ok>(true);
+  assert<IsExact<typeof r.val, number>>(true);
+}
+//#endregion
+//#region Ok<T> & Err<E> should be Result<T, E>
+{
+  const r1 = new Err(0);
+  const r2 = new Ok("");
+  const r = Math.random() ? r1 : r2;
+  assert<IsExact<typeof r, Result<string, number>>>(true);
+}
+//#endregion
+//#region static EMPTY
+assert<IsExact<typeof Err.EMPTY, Err<void>>>(true);
+assert<IsExact<typeof Ok.EMPTY, Ok<void>>>(true);
+//#endregion
+//#region Type narrowing test (tagged union)
+{
+  const r = work();
+  if (r.ok) {
+    assert<IsExact<typeof r, Ok<string>>>(true);
+  } else {
+    assert<IsExact<typeof r, Err<number>>>(true);
+  }
+  // ---------------------------------------------
+  if (r.err) {
+    assert<IsExact<typeof r, Err<number>>>(true);
+  } else {
+    assert<IsExact<typeof r, Ok<string>>>(true);
+  }
+}
+//#endregion
+//#region Type narrowing test (instanceof)
+{
+  const r = work();
+  if (r instanceof Ok) {
+    assert<IsExact<typeof r, Ok<string>>>(true);
+  } else {
+    assert<IsExact<typeof r, Err<number>>>(true);
+  }
+  // ---------------------------------------------
+  if (r instanceof Err) {
+    assert<IsExact<typeof r, Err<number>>>(true);
+  } else {
+    assert<IsExact<typeof r, Ok<string>>>(true);
+  }
+}
+//#endregion
+//#region !!! NOT PASSING: else(val)
+{
+  const r1 = ok().else(false);
+  expect_string(r1);
+
+  const r2 = err().else(false);
+  assert<IsExact<false, typeof r2>>(true);
+
+  // FIXME: GH#4 TS2349: This expression (Result<?, ?>.else) is not callable
+  // @ts-expect-error
+  const r3 = work().else(false);
+  // @ts-expect-error
+  assert<IsExact<typeof r3, string | false>>(true);
+}
+//#endregion
+//#region expect(msg)
+{
+  const r1 = ok().expect("");
+  expect_string(r1);
+  const r2 = err().expect("");
+  expect_never(r2);
+  const r3 = work().expect("");
+  expect_string(r3);
+}
+//#endregion
+//#region unwrap()
+{
+  const r1 = ok().unwrap();
+  expect_string(r1);
+  const r2 = err().unwrap();
+  expect_never(r2);
+  const r3 = work().unwrap();
+  expect_string(r3);
+}
+//#endregion
+//#region map(mapper)
+{
+  const r1 = ok().map(Symbol);
+  assert<IsExact<typeof r1, Ok<symbol>>>(true);
+  const r2 = err().map((x) => Symbol());
+  assert<IsExact<typeof r2, Err<number>>>(true);
+  const r3 = work().map(Symbol);
+  assert<IsExact<typeof r3, Result<symbol, number>>>(true);
+}
+//#endregion
+//#region mapErr(mapper)
+{
+  const r1 = ok().mapErr(Symbol);
+  assert<IsExact<typeof r1, Ok<string>>>(true);
+  const r2 = err().mapErr((x) => Symbol());
+  assert<IsExact<typeof r2, Err<symbol>>>(true);
+  const r3 = work().mapErr(Symbol);
+  assert<IsExact<typeof r3, Result<string, symbol>>>(true);
+}
+//#endregion
+//#region ResultOkType & ResultErrType
+{
+  type a = ResultOkType<Ok<string>>;
+  assert<IsExact<string, a>>(true);
+  type b = ResultOkType<Err<string>>;
+  assert<IsExact<never, b>>(true);
+  type c = ResultOkType<Result<string, number>>;
+  assert<IsExact<string, c>>(true);
+}
+{
+  type a = ResultErrType<Ok<string>>;
+  assert<IsExact<never, a>>(true);
+  type b = ResultErrType<Err<string>>;
+  assert<IsExact<string, b>>(true);
+  type c = ResultErrType<Result<string, number>>;
+  assert<IsExact<number, c>>(true);
+}
+//#endregion
+//#region !!! NOT PASSING: Results(...args)
+{
+  const r0 = Results();
+  // @ts-expect-error, actually Result<any[], any>
+  assert<IsExact<typeof r0, Result<[], void>>>(true);
+  const r1 = Results(work());
+  // @ts-expect-error, actually Result<any[], any>
+  assert<IsExact<typeof r1, Result<[string], number>>>(true);
+  const r2 = Results(work(), work());
+  assert<IsExact<typeof r2, Result<[string, string], number>>>(true);
+  const r3 = Results(ok(), err(), work());
+  assert<IsExact<typeof r3, Result<[string, never, string], number>>>(true);
+}
+//#endregion
+function expect_string(x: string) {}
+function expect_never(x: never) {}

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,11 +1,11 @@
 import { assert, IsExact, IsNever } from "conditional-type-checks";
 import {
-  Err,
-  Ok,
-  Result,
-  ResultOkType,
-  ResultErrType,
-  Results,
+    Err,
+    Ok,
+    Result,
+    ResultOkType,
+    ResultErrType,
+    Results,
 } from "../dist/index";
 
 declare function work(): Result<string, number>;
@@ -14,32 +14,32 @@ declare function ok(): Ok<string>;
 declare function err(): Err<number>;
 //#region Callable
 {
-  const x = Err(0);
-  eq<Err<number>, typeof x>(true);
-  const y = Ok(0);
-  eq<Ok<number>, typeof y>(true);
+    const x = Err(0);
+    eq<Err<number>, typeof x>(true);
+    const y = Ok(0);
+    eq<Ok<number>, typeof y>(true);
 }
 //#endregion
 //#region ok, err, val
 {
-  const r = new Err(0);
-  assert<typeof r.err>(true);
-  assert<typeof r.ok>(false);
-  eq<typeof r.val, number>(true);
+    const r = new Err(0);
+    assert<typeof r.err>(true);
+    assert<typeof r.ok>(false);
+    eq<typeof r.val, number>(true);
 }
 {
-  const r = new Ok(0);
-  assert<typeof r.err>(false);
-  assert<typeof r.ok>(true);
-  eq<typeof r.val, number>(true);
+    const r = new Ok(0);
+    assert<typeof r.err>(false);
+    assert<typeof r.ok>(true);
+    eq<typeof r.val, number>(true);
 }
 //#endregion
 //#region Ok<T> & Err<E> should be Result<T, E>
 {
-  const r1 = new Err(0);
-  const r2 = new Ok("");
-  const r = Math.random() ? r1 : r2;
-  eq<typeof r, Result<string, number>>(true);
+    const r1 = new Err(0);
+    const r2 = new Ok("");
+    const r = Math.random() ? r1 : r2;
+    eq<typeof r, Result<string, number>>(true);
 }
 //#endregion
 //#region static EMPTY
@@ -48,153 +48,159 @@ eq<typeof Ok.EMPTY, Ok<void>>(true);
 //#endregion
 //#region Type narrowing test (tagged union)
 {
-  const r = work();
-  if (r.ok) {
-    eq<typeof r, Ok<string>>(true);
-  } else {
-    eq<typeof r, Err<number>>(true);
-  }
-  // ---------------------------------------------
-  if (r.err) {
-    eq<typeof r, Err<number>>(true);
-  } else {
-    eq<typeof r, Ok<string>>(true);
-  }
+    const r = work();
+    if (r.ok) {
+        eq<typeof r, Ok<string>>(true);
+    } else {
+        eq<typeof r, Err<number>>(true);
+    }
+    // ---------------------------------------------
+    if (r.err) {
+        eq<typeof r, Err<number>>(true);
+    } else {
+        eq<typeof r, Ok<string>>(true);
+    }
 }
 //#endregion
 //#region Type narrowing test (instanceof)
 {
-  const r = work();
-  if (r instanceof Ok) {
-    eq<typeof r, Ok<string>>(true);
-  } else {
-    eq<typeof r, Err<number>>(true);
-  }
-  // ---------------------------------------------
-  if (r instanceof Err) {
-    eq<typeof r, Err<number>>(true);
-  } else {
-    eq<typeof r, Ok<string>>(true);
-  }
+    const r = work();
+    if (r instanceof Ok) {
+        eq<typeof r, Ok<string>>(true);
+    } else {
+        eq<typeof r, Err<number>>(true);
+    }
+    // ---------------------------------------------
+    if (r instanceof Err) {
+        eq<typeof r, Err<number>>(true);
+    } else {
+        eq<typeof r, Ok<string>>(true);
+    }
 }
 //#endregion
 //#region else(val)
 {
-  const r1 = ok().else(false);
-  expect_string(r1, true);
+    const r1 = ok().else(false);
+    expect_string(r1, true);
 
-  const r2 = err().else(false);
-  eq<false, typeof r2>(true);
+    const r2 = err().else(false);
+    eq<false, typeof r2>(true);
 
-  const r3 = work().else(false);
-  eq<typeof r3, string | false>(true);
+    const r3 = work().else(false);
+    eq<typeof r3, string | false>(true);
 }
 //#endregion
 //#region expect(msg)
 {
-  const r1 = ok().expect("");
-  expect_string(r1, true);
-  const r2 = err().expect("");
-  expect_never(r2, true);
-  const r3 = work().expect("");
-  expect_string(r3, true);
+    const r1 = ok().expect("");
+    expect_string(r1, true);
+    const r2 = err().expect("");
+    expect_never(r2, true);
+    const r3 = work().expect("");
+    expect_string(r3, true);
 }
 //#endregion
 //#region unwrap()
 {
-  const r1 = ok().unwrap();
-  expect_string(r1, true);
-  const r2 = err().unwrap();
-  expect_never(r2, true);
-  const r3 = work().unwrap();
-  expect_string(r3, true);
+    const r1 = ok().unwrap();
+    expect_string(r1, true);
+    const r2 = err().unwrap();
+    expect_never(r2, true);
+    const r3 = work().unwrap();
+    expect_string(r3, true);
 }
 //#endregion
 //#region map(mapper)
 {
-  const r1 = ok().map(Symbol);
-  eq<typeof r1, Ok<symbol>>(true);
-  const r2 = err().map((x) => Symbol());
-  eq<typeof r2, Err<number>>(true);
-  const r3 = work().map(Symbol);
-  eq<typeof r3, Result<symbol, number>>(true);
+    const r1 = ok().map(Symbol);
+    eq<typeof r1, Ok<symbol>>(true);
+    const r2 = err().map((x) => Symbol());
+    eq<typeof r2, Err<number>>(true);
+    const r3 = work().map(Symbol);
+    eq<typeof r3, Result<symbol, number>>(true);
 }
 //#endregion
 //#region flatMap
 {
-  const r1 = ok().flatMap(work);
-  eq<typeof r1, Result<string, number>>(true);
-  const r2 = err().flatMap(work);
-  eq<typeof r2, Err<number>>(true);
-  const r3 = work().flatMap(work2);
-  eq<typeof r3, Result<symbol, string | number>>(true);
+    const r1 = ok().flatMap(work);
+    eq<typeof r1, Result<string, number>>(true);
+    const r2 = err().flatMap(work);
+    eq<typeof r2, Err<number>>(true);
+    const r3 = work().flatMap(work2);
+    eq<typeof r3, Result<symbol, string | number>>(true);
 }
 //#endregion
 //#region mapErr(mapper)
 {
-  const r1 = ok().mapErr(Symbol);
-  eq<typeof r1, Ok<string>>(true);
-  const r2 = err().mapErr((x) => Symbol());
-  eq<typeof r2, Err<symbol>>(true);
-  const r3 = work().mapErr(Symbol);
-  eq<typeof r3, Result<string, symbol>>(true);
+    const r1 = ok().mapErr(Symbol);
+    eq<typeof r1, Ok<string>>(true);
+    const r2 = err().mapErr((x) => Symbol());
+    eq<typeof r2, Err<symbol>>(true);
+    const r3 = work().mapErr(Symbol);
+    eq<typeof r3, Result<string, symbol>>(true);
 }
 //#endregion
 //#region ResultOkType & ResultErrType
 {
-  type a = ResultOkType<Ok<string>>;
-  eq<string, a>(true);
-  type b = ResultOkType<Err<string>>;
-  eq<never, b>(true);
-  type c = ResultOkType<Result<string, number>>;
-  eq<string, c>(true);
+    type a = ResultOkType<Ok<string>>;
+    eq<string, a>(true);
+    type b = ResultOkType<Err<string>>;
+    eq<never, b>(true);
+    type c = ResultOkType<Result<string, number>>;
+    eq<string, c>(true);
 }
 {
-  type a = ResultErrType<Ok<string>>;
-  eq<never, a>(true);
-  type b = ResultErrType<Err<string>>;
-  eq<string, b>(true);
-  type c = ResultErrType<Result<string, number>>;
-  eq<number, c>(true);
+    type a = ResultErrType<Ok<string>>;
+    eq<never, a>(true);
+    type b = ResultErrType<Err<string>>;
+    eq<string, b>(true);
+    type c = ResultErrType<Result<string, number>>;
+    eq<number, c>(true);
 }
 //#endregion
 //#region Results(...args)
 {
-  const r0 = Results();
-  eq<typeof r0, Result<[], never>>(true);
-  const r1 = Results(work());
-  eq<typeof r1, Result<[string], number>>(true);
-  const r2 = Results(work(), work());
-  eq<typeof r2, Result<[string, string], number>>(true);
-  const r3 = Results(ok(), err(), work());
-  eq<typeof r3, Result<[string, never, string], number>>(true);
+    const r0 = Results();
+    eq<typeof r0, Result<[], never>>(true);
+    const r1 = Results(work());
+    eq<typeof r1, Result<[string], number>>(true);
+    const r2 = Results(work(), work());
+    eq<typeof r2, Result<[string, string], number>>(true);
+    const r3 = Results(ok(), err(), work());
+    eq<typeof r3, Result<[string, never, string], number>>(true);
 }
 //#endregion
 //#region Iterable<T>
 {
-  const x = work()[Symbol.iterator];
-  assert<
-    IsExact<
-      typeof x,
-      | (() => Iterator<string, any, undefined>)
-      | (() => Iterator<never, any, undefined>)
-    >
-  >(true);
-  for (const char of work()) {
-    expect_string(char, true);
-  }
-  for (const item of Ok([1, 2, 3])) {
-    assert<IsExact<number, typeof item>>(true);
-  }
-  for (const item of Err(0)) {
-    expect_never(item, true);
-    throw new Error(
-      "Unreachable, Err@@iterator should emit no value and return"
-    );
-  }
-  // @ts-expect-error An iterator must have a 'next()' method.ts(2489)
-  for (const expectError of Ok(1)) {
-  }
+    const x = work()[Symbol.iterator];
+    assert<
+        IsExact<
+            typeof x,
+            | (() => Iterator<string, any, undefined>)
+            | (() => Iterator<never, any, undefined>)
+        >
+    >(true);
+    for (const char of work()) {
+        expect_string(char, true);
+    }
+    for (const item of Ok([1, 2, 3])) {
+        assert<IsExact<number, typeof item>>(true);
+    }
+    for (const item of Err(0)) {
+        expect_never(item, true);
+        throw new Error(
+            "Unreachable, Err@@iterator should emit no value and return"
+        );
+    }
+    // @ts-expect-error An iterator must have a 'next()' method.ts(2489)
+    for (const expectError of Ok(1)) {
+    }
+}
+//#endregion
+//#region static wrap
+{
+    const a = Ok.wrap(() => 1);
+    assert<IsExact<typeof a, Result<number, unknown>>>(true);
 }
 //#endregion
 function expect_string<T>(x: T, y: IsExact<T, string>) {}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "strict": true,
+    "noEmit": true,
+    "moduleResolution": "Node"
+  },
+  "include": ["./**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "./dist/",
     "sourceMap": true,
     "declaration": true,
+    "declarationMap": true,
     "moduleResolution": "node",
     "module": "es2015",
     "noEmitHelpers": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,14 +13,9 @@
     "noImplicitReturns": true,
     "baseUrl": "./",
     "target": "es6",
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true
   },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "node_modules",
-    "./dist",
-    "**/*.spec.ts"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "./dist", "**/*.spec.ts"]
 }


### PR DESCRIPTION
- chore: upgrade dependencies
- chore: cleanup code
- test: write test for main function
- fix #4 (TS2349: This expression (Result<?, ?>.else) is not callable)
- close #3 (Call without `new`, Now it is possibe to easily transfrom Promise into checked exception `promise.then(Ok, Err)`)
- close #8 (Implement `andThen` in Rust)
- fix: Results type on 0 or 1 args
- feat: impl `Symbol.iterator` for Ok
- feat: add a new helper `wrap` (`wrap(() => fnMayThrowError())`) to convert `try-catch` style in to checked exception
- feat: add a new helper `any`. (`Results`(`all`) compare to `any`)
- feat: add `safeUnwrap` (`into_ok` in Rust) that unwrap in the compile time.