### PR TITLE
[rfc] Add stack property to Err

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "ts-results",
-    "version": "3.1.0",
+    "version": "3.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/test/err.test.ts
+++ b/test/err.test.ts
@@ -95,3 +95,9 @@ test('to string', () => {
     expect(`${Err(1)}`).toEqual('Err(1)');
     expect(`${Err({ name: 'George' })}`).toEqual('Err({"name":"George"})');
 });
+
+test('stack trace', () => {
+    expect(Err(1).stack).toMatch(/err\.test\.ts/);
+    expect(Err(1).stack).toMatch(/Err\(1\)/);
+    expect(Err(1).stack).not.toMatch(/ErrImpl/);
+});


### PR DESCRIPTION
We've got some people using `ts-results` now and the lack of stack traces is starting to be a little annoying and slowing down debugging. This adds a `.stack` property to `Err` which helps address the issue.

A few questions:
* Do we even want to offer this?
* This probably comes at some performance cost, but it seems negligible: https://stackoverflow.com/questions/35306496/performance-hit-of-newing-up-error-object-in-modern-node-js. Should we provide a way to disable it? Or perhaps disable based on `NODE_ENV`?
* Should the stack trace be automatically included in `toString()`? Or should we require users to access `.stack` explicitly?
* Should `Ok` and `Option` get stack traces?
