### PR TITLE
Patch: remove tslib requirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "ts-results",
-    "version": "3.2.1",
+    "version": "3.3.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
     "baseUrl": "./",
     // NOTE: Don't change this from es5 - we use this to allow callable classes.
     "target": "es5",
-    "importHelpers": true,
     "forceConsistentCasingInFileNames": true,
     "experimentalDecorators": true
   },


### PR DESCRIPTION
Closes #19, closes #31, closes #32

Tests pass. The only output difference is in dist/index.js which no longer includes:
```javascript
var tslib_1 = require("tslib");
```

But instead simply inlines the single method:
```javascript
var __exportStar = (this && this.__exportStar) || function(m, exports) {
    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
};
```