### PR TITLE
Fix two "argument ... is not assignable to parameter" errors

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -327,7 +327,7 @@ export namespace Result {
         try {
             return new Ok(op());
         } catch (e) {
-            return new Err<E>(e);
+            return new Err<E>(e as E);
         }
     }
 
@@ -341,7 +341,7 @@ export namespace Result {
                 .then((val) => new Ok(val))
                 .catch((e) => new Err(e));
         } catch (e) {
-            return Promise.resolve(new Err(e));
+            return Promise.resolve(new Err(e as E));
         }
     }
 


### PR DESCRIPTION
The yarn/tsc/node versions I'm running:

    # yarn --version
    1.22.17

    # yarn run tsc --version
    yarn run v1.22.17
    $ /ts-results/node_modules/.bin/tsc --version
    Version 4.5.5
    Done in 0.14s.

    # node --version
    v17.5.0

The errors:

    # yarn build
    yarn run v1.22.17
    $ npm run clean && npm run build:ts && npm run build:copy

    > ts-results@3.3.0 clean
    > rm -rf dist

    > ts-results@3.3.0 build:ts
    > tsc -p tsconfig.json && tsc -p tsconfig.json -m esnext --outDir dist/esm/ -d false -declarationMap false

    src/result.ts:330:31 - error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'E'.
      'E' could be instantiated with an arbitrary type which could be unrelated to 'unknown'.

    330             return new Err<E>(e);
                                      ~

    src/result.ts:344:13 - error TS2322: Type 'Promise<ErrImpl<unknown>>' is not assignable to type 'Promise<Result<T, E>>'.
      Type 'ErrImpl<unknown>' is not assignable to type 'Result<T, E>'.
        Type 'ErrImpl<unknown>' is not assignable to type 'Err<E>'.
          Type 'unknown' is not assignable to type 'E'.
            'E' could be instantiated with an arbitrary type which could be unrelated to 'unknown'.

    344             return Promise.resolve(new Err(e));
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

    Found 2 errors.

    error Command failed with exit code 2.
    info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.