### PR TITLE
variant, match and tap

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -1,5 +1,6 @@
 import { toString } from './utils';
 import { Result, Ok, Err } from './result';
+import { Variant } from './variant';
 
 interface BaseOption<T> extends Iterable<T extends Iterable<infer U> ? U : never> {
     /** `true` when the Option is Some */ readonly some: boolean;
@@ -50,7 +51,7 @@ interface BaseOption<T> extends Iterable<T extends Iterable<infer U> ? U : never
 /**
  * Contains the None value
  */
-class NoneImpl implements BaseOption<never> {
+class NoneImpl<T> extends Variant('None') implements BaseOption<T> {
     readonly some = false;
     readonly none = true;
 
@@ -92,14 +93,14 @@ class NoneImpl implements BaseOption<never> {
 }
 
 // Export None as a singleton, then freeze it so it can't be modified
-export const None = new NoneImpl();
-export type None = NoneImpl;
+export const None = new NoneImpl<never>();
+export type None = NoneImpl<never>;
 Object.freeze(None);
 
 /**
  * Contains the success value
  */
-class SomeImpl<T> implements BaseOption<T> {
+class SomeImpl<T> extends Variant('Some')<[T]> implements BaseOption<T> {
     static readonly EMPTY = new SomeImpl<void>(undefined);
 
     readonly some!: true;
@@ -122,6 +123,7 @@ class SomeImpl<T> implements BaseOption<T> {
     }
 
     constructor(val: T) {
+        super(val);
         if (!(this instanceof SomeImpl)) {
             return new SomeImpl(val);
         }

--- a/src/variant.ts
+++ b/src/variant.ts
@@ -1,0 +1,69 @@
+type MatcherMap<T extends string, Args extends unknown[], R> = {
+    [key in T]: (...args: Args) => R;
+};
+
+type AnythingMatcherMap<R> = { _(): R };
+
+/**
+ * The Variant class factory implements the `.match` and `.tap` methods that allow to define logic
+ * that runs depending of the type for each type within a union of different Variant types. It
+ * allows you to do pattern matching as long as each type extends from Variant
+ */
+export const Variant = <T extends string>(type: T) =>
+    class<Args extends unknown[] = []> {
+        readonly args: Args;
+        readonly type: T;
+
+        constructor(...args: Args) {
+            this.args = args;
+            this.type = type;
+        }
+
+        /**
+         * Define handlers for each of the possible variants this variant could be, allows for a `_`
+         * wildcard to handle all remaining variants. Returns the value the matching handler returns.
+         *
+         * ```ts
+         * declare class Some<T> extends Variant('Some')<[T]>;
+         * declare class None extends Variant('None')<[]>;
+         *
+         * declare const option: Some<number> | None;
+         * const double = option.match({
+         *     Some: (x) => x * 2,
+         *     None: () => 0
+         * })
+         * const isSome = shape.match({
+         *     Some: () => true,
+         *     // matches any other variant
+         *     _: () => false
+         * })
+         * ```
+         */
+        match<R>(matcher: MatcherMap<T, Args, R> | AnythingMatcherMap<R>): R;
+        match<R>(matcher: MatcherMap<T, Args, R> & AnythingMatcherMap<R>): R {
+            return this.type in matcher ? matcher[this.type](...this.args) : matcher._();
+        }
+
+        /**
+         * Same as `match` but should be used instead to fire side effects that only run if a handler
+         * exists for the given variant, not all variants need to have a handler defined.
+         * Does not return a value.
+         *
+         * ```ts
+         * declare class Some<T> extends Variant('Some')<[T]>;
+         * declare class None extends Variant('None')<[]>;
+         *
+         * declare const option: Some<number> | None;
+         * option.tap({
+         *     None() {
+         *         console.log("It's empty!");
+         *     }
+         *    // If the variant is anything else nothing happens
+         * });
+         * ```
+         */
+        tap(matcher: Partial<MatcherMap<T, Args, void>>): this {
+            matcher[this.type]?.(...this.args);
+            return this;
+        }
+    };

--- a/test/option.test.ts
+++ b/test/option.test.ts
@@ -119,3 +119,34 @@ test('to result', () => {
 
     expect(result2).toMatchResult(Err('error'));
 });
+
+test('match', () => {
+    const option = Some(1) as Option<number>;
+    expect(
+        option.match({
+            Some: (v) => v,
+            None: () => 0,
+        }),
+    ).toBe(1);
+
+    expect(
+        option.match({
+            None: () => 0,
+            _: () => 2,
+        }),
+    ).toBe(2);
+});
+
+test('tap', () => {
+    const option = Some(1) as Option<number>;
+    const matched = jest.fn();
+    const unmatched = jest.fn();
+    option.tap({
+        Some: matched,
+    });
+    option.tap({
+        None: unmatched,
+    });
+    expect(matched).toHaveBeenCalled();
+    expect(unmatched).not.toHaveBeenCalled();
+});

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -247,3 +247,34 @@ test('To option', () => {
     const option2 = result2.toOption();
     expect(option2).toEqual(None);
 });
+
+test('match', () => {
+    const result = Ok(1) as Result<number, string>;
+    expect(
+        result.match({
+            Ok: (v) => v,
+            Err: () => 0,
+        }),
+    ).toBe(1);
+
+    expect(
+        result.match({
+            Err: () => 0,
+            _: () => 2,
+        }),
+    ).toBe(2);
+});
+
+test('tap', () => {
+    const result = Ok(1) as Result<number, string>;
+    const matched = jest.fn();
+    const unmatched = jest.fn();
+    result.tap({
+        Ok: matched,
+    });
+    result.tap({
+        Err: unmatched,
+    });
+    expect(matched).toHaveBeenCalled();
+    expect(unmatched).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
Introduce the `Variant` class factory, which allows option and result types to do `match` and `tap` as seen in the tests

closes #52 