### PR TITLE
Remove expectErr

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Brings compile-time error checking and optional values to typescript.
     -   [Type Safety](#type-safety)
     -   [Unwrap](#unwrap)
     -   [Expect](#expect)
-    -   [ExpectErr](#expecterr)
     -   [Map, MapErr](#map-and-maperr)
     -   [andThen](#andthen)
     -   [Else](#else)
@@ -202,17 +201,6 @@ let badResult = Err(new Error('something went wrong'));
 goodResult.expect('goodResult should be a number'); // 1
 badResult.expect('badResult should be a number'); // throws Error("badResult should be a number - Error: something went wrong")
 ```
-
-#### ExpectErr
-
-```typescript
-let goodResult = Ok(1);
-let badResult = Err(new Error('something went wrong'));
-
-goodResult.expect('goodResult should not be a number'); // throws Error("goodResult should not be a number")
-badResult.expect('badResult should not be a number'); // new Error('something went wrong')
-```
-
 
 #### Map and MapErr
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -26,12 +26,6 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
     expect(msg: string): T;
 
     /**
-     * Returns the contained `Ok` value, if does not exist.  Throws an error if it does.
-     * @param msg the message to throw if Ok value.
-     */
-    expectErr(msg: string): T;
-    
-    /**
      * Returns the contained `Ok` value.
      * Because this function may throw, its use is generally discouraged.
      * Instead, prefer to handle the `Err` case explicitly.
@@ -142,10 +136,6 @@ export class ErrImpl<E> implements BaseResult<never, E> {
         throw new Error(`${msg} - Error: ${toString(this.val)}\n${this._stack}`);
     }
 
-    expectErr(_msg: string): E {
-        return this.val
-    }
-
     unwrap(): never {
         throw new Error(`Tried to unwrap Error: ${toString(this.val)}\n${this._stack}`);
     }
@@ -228,10 +218,6 @@ export class OkImpl<T> implements BaseResult<T, never> {
 
     expect(_msg: string): T {
         return this.val;
-    }
-
-    expectErr(msg: string): never {
-        throw new Error(msg);
     }
 
     unwrap(): T {


### PR DESCRIPTION
This method is confusing, it takes an error message in case the error is missing, why have it?