### PR TITLE
Remove toResult

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -40,11 +40,6 @@ interface BaseOption<T> extends Iterable<T extends Iterable<infer U> ? U : never
      * This function can be used to compose the Options of two functions.
      */
     map<U>(mapper: (val: T) => U): Option<U>;
-
-    /**
-     * Maps an `Option<T>` to a `Result<T, E>`.
-     */
-    toResult<E>(error: E): Result<T, E>;
 }
 
 /**
@@ -80,10 +75,6 @@ class NoneImpl implements BaseOption<never> {
 
     andThen<T2>(op: unknown): None {
         return this;
-    }
-
-    toResult<E>(error: E): Err<E> {
-        return Err(error);
     }
 
     toString(): string {
@@ -149,10 +140,6 @@ class SomeImpl<T> implements BaseOption<T> {
 
     andThen<T2>(mapper: (val: T) => Option<T2>): Option<T2> {
         return mapper(this.val);
-    }
-
-    toResult<E>(error: E): Ok<T> {
-        return Ok(this.val);
     }
 
     /**

--- a/test/option.test.ts
+++ b/test/option.test.ts
@@ -1,4 +1,4 @@
-import { Err, None, Ok, Option, OptionSomeType, Result, Some } from '../src';
+import { None, Option, OptionSomeType, Some } from '../src';
 import { eq } from './util';
 
 const someString = Some('foo');
@@ -104,18 +104,4 @@ test('to string', () => {
     expect(`${Some(1)}`).toEqual('Some(1)');
     expect(`${Some({ name: 'George' })}`).toEqual('Some({"name":"George"})');
     expect(`${None}`).toEqual('None');
-});
-
-test('to result', () => {
-    const option = Some(1) as Option<number>;
-    const result = option.toResult('error');
-    eq<typeof result, Result<number, string>>(true);
-
-    expect(result).toMatchResult(Ok(1));
-
-    const option2 = None as Option<number>;
-    const result2 = option2.toResult('error');
-    eq<typeof result2, Result<number, string>>(true);
-
-    expect(result2).toMatchResult(Err('error'));
 });


### PR DESCRIPTION
After #61 gets merged this can be achieved by doing

```ts
option.match({
  Some: Ok,
  None: () => Err('<custom error>')
})
```