### PR TITLE
Add isOk, isErr, isSome and isNone methods and remove flags

### DIFF
--- a/src/rxjs-operators/index.ts
+++ b/src/rxjs-operators/index.ts
@@ -31,9 +31,9 @@ export function elseMap<T, E, E2>(mapper: (val: E) => E2): OperatorFunction<Resu
         return source.pipe(
             map((result) => {
                 if (result.err) {
-                    return mapper(result.val);
+                    return mapper(result.error);
                 } else {
-                    return result.val;
+                    return result.error;
                 }
             }),
         );
@@ -47,7 +47,7 @@ export function elseMapTo<T, E, E2>(value: E2): OperatorFunction<Result<T, E>, T
                 if (result.err) {
                     return value;
                 } else {
-                    return result.val;
+                    return result.error;
                 }
             }),
         );
@@ -67,7 +67,7 @@ export function resultSwitchMap<T, E, T2, E2>(
         return source.pipe(
             switchMap((result) => {
                 if (result.ok) {
-                    return mapper(result.val);
+                    return mapper(result.error);
                 } else {
                     return of(result);
                 }
@@ -96,7 +96,7 @@ export function resultMergeMap<T, E, T2, E2>(
         return source.pipe(
             mergeMap((result) => {
                 if (result.ok) {
-                    return mapper(result.val);
+                    return mapper(result.error);
                 } else {
                     return of(result);
                 }
@@ -116,7 +116,7 @@ export function filterResultOk<T, E>(): OperatorFunction<Result<T, E>, T> {
     return (source) => {
         return source.pipe(
             filter((result): result is Ok<T> => result.ok),
-            map((result) => result.val),
+            map((result) => result.value),
         );
     };
 }
@@ -125,7 +125,7 @@ export function filterResultErr<T, E>(): OperatorFunction<Result<T, E>, E> {
     return (source) => {
         return source.pipe(
             filter((result): result is Err<E> => result.err),
-            map((result) => result.val),
+            map((result) => result.error),
         );
     };
 }
@@ -135,7 +135,7 @@ export function tapResultErr<T, E>(tapFn: (err: E) => void): MonoTypeOperatorFun
         return source.pipe(
             tap((r) => {
                 if (!r.ok) {
-                    tapFn(r.val);
+                    tapFn(r.error);
                 }
             }),
         );
@@ -147,7 +147,7 @@ export function tapResultOk<T, E>(tapFn: (val: T) => void): MonoTypeOperatorFunc
         return source.pipe(
             tap((r) => {
                 if (r.ok) {
-                    tapFn(r.val);
+                    tapFn(r.error);
                 }
             }),
         );

--- a/test/err.test.ts
+++ b/test/err.test.ts
@@ -32,13 +32,13 @@ test('ok, err, and val', () => {
     expect(err.ok).toBe(false);
     assert<typeof err.ok>(false);
 
-    expect(err.val).toBe(32);
-    eq<typeof err.val, number>(true);
+    expect(err.error).toBe(32);
+    eq<typeof err.error, number>(true);
 });
 
 test('static EMPTY', () => {
     expect(Err.EMPTY).toBeInstanceOf(Err);
-    expect(Err.EMPTY.val).toBe(undefined);
+    expect(Err.EMPTY.error).toBe(undefined);
     eq<typeof Err.EMPTY, Err<void>>(true);
 });
 

--- a/test/ok.test.ts
+++ b/test/ok.test.ts
@@ -33,13 +33,13 @@ test('ok, err, and val', () => {
     expect(err.ok).toBe(true);
     assert<typeof err.ok>(true);
 
-    expect(err.val).toBe(32);
-    eq<typeof err.val, number>(true);
+    expect(err.value).toBe(32);
+    eq<typeof err.value, number>(true);
 });
 
 test('static EMPTY', () => {
     expect(Ok.EMPTY).toBeInstanceOf(Ok);
-    expect(Ok.EMPTY.val).toBe(undefined);
+    expect(Ok.EMPTY.value).toBe(undefined);
     eq<typeof Ok.EMPTY, Ok<void>>(true);
 });
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -26,8 +26,8 @@ expect.extend({
         try {
             expect(received.ok).toBe(result.ok);
 
-            if (received.val !== result.val) {
-                expect(received.val).toMatchObject(result.val);
+            if (received.error !== result.error) {
+                expect(received.error).toMatchObject(result.error);
             }
         } catch (e) {
             pass = false;
@@ -35,8 +35,8 @@ expect.extend({
 
         const type = received.ok ? 'Ok' : 'Err';
         const expectedType = received.ok ? 'Ok' : 'Err';
-        const val = JSON.stringify(received.val);
-        const expectedVal = JSON.stringify(result.val);
+        const val = JSON.stringify(received.error);
+        const expectedVal = JSON.stringify(result.error);
 
         return {
             message: () => `expected ${type}(${val}) ${pass ? '' : 'not '}to equal ${expectedType}(${expectedVal})`,
@@ -52,8 +52,8 @@ expect.extend({
 
             expect(received?.ok).toBe(result.ok);
 
-            if (received?.val !== result.val) {
-                expect(received?.val).toMatchObject(result.val);
+            if (received?.error !== result.error) {
+                expect(received?.error).toMatchObject(result.error);
             }
         } catch (e) {
             pass = false;
@@ -61,8 +61,8 @@ expect.extend({
 
         const type = received?.ok ? 'Ok' : 'Err';
         const expectedType = received?.ok ? 'Ok' : 'Err';
-        const val = JSON.stringify(received?.val);
-        const expectedVal = JSON.stringify(result.val);
+        const val = JSON.stringify(received?.error);
+        const expectedVal = JSON.stringify(result.error);
 
         return {
             message: () => `expected ${type}(${val}) ${pass ? '' : 'not '}to equal ${expectedType}(${expectedVal})`,


### PR DESCRIPTION
Let's get closer to Rust on this API, also the flag names `some` `none` `ok` and `err` have confusing names, it's hard to tell if they should be a boolean or not