### PR TITLE
Fix expectErr implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,8 @@ badResult.expect('badResult should be a number'); // throws Error("badResult sho
 let goodResult = Ok(1);
 let badResult = Err(new Error('something went wrong'));
 
-goodResult.expect('goodResult should not be a number'); // throws Error("goodResult should not be a number")
-badResult.expect('badResult should not be a number'); // new Error('something went wrong')
+goodResult.expectErr('goodResult should not be a number'); // throws Error("goodResult should not be a number")
+badResult.expectErr('badResult should not be a number'); // new Error('something went wrong')
 ```
 
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -26,11 +26,11 @@ interface BaseResult<T, E> extends Iterable<T extends Iterable<infer U> ? U : ne
     expect(msg: string): T;
 
     /**
-     * Returns the contained `Ok` value, if does not exist.  Throws an error if it does.
+     * Returns the contained `Error` value, if it exist.  Throws an error if it does not.
      * @param msg the message to throw if Ok value.
      */
-    expectErr(msg: string): T;
-    
+    expectErr(msg: string): E;
+
     /**
      * Returns the contained `Ok` value.
      * Because this function may throw, its use is generally discouraged.
@@ -143,7 +143,7 @@ export class ErrImpl<E> implements BaseResult<never, E> {
     }
 
     expectErr(_msg: string): E {
-        return this.val
+        return this.val;
     }
 
     unwrap(): never {

--- a/test/err.test.ts
+++ b/test/err.test.ts
@@ -59,6 +59,11 @@ test('expect', () => {
     }).toThrowError('should fail!');
 });
 
+test('expectErr', () => {
+    const err = Err(true);
+    expect(err.expectErr('Error message')).toBe(true);
+});
+
 test('unwrap', () => {
     expect(() => {
         const err = Err({ message: 'bad error' }).unwrap();

--- a/test/ok.test.ts
+++ b/test/ok.test.ts
@@ -59,6 +59,14 @@ test('expect', () => {
     eq<boolean, typeof val>(true);
 });
 
+test('expectErr', () => {
+    const ok = Ok(true);
+    const errorMsg = 'Error message';
+    expect(() => {
+        ok.expectErr(errorMsg);
+    }).toThrow(errorMsg);
+});
+
 test('unwrap', () => {
     const val = Ok(true).unwrap();
     expect(val).toBe(true);


### PR DESCRIPTION
This pull request does three things.
- Fixes the type on `expectErr` in `BaseResult`
- Adds `expectErr` tests in the ok and err  test files.
- Updates the Readme to call `expectErr` instead of `expect`

Fixes #74 

@vultix is this repo still active?